### PR TITLE
Solve bug for installation on linux

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -26,8 +26,6 @@ Ubuntu/Linux:
         sudo pip3 install --upgrade matplotlib
         sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp34-cp34m-linux_x86_64.whl
 
-    The cycler install is to work around a bug in the current matplotlib release. It should be fixed in the next one.
-    The renaming of the tensorflow install file is to overcome a bug in tensorflow. This should get fixed too.
 
 TEST YOUR INSTALLATION:
     git clone https://github.com/martin-gorner/tensorflow-mnist-tutorial.git

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -21,14 +21,10 @@ Windows:
 	Now go to Ubuntu/Linux section.
 
 Ubuntu/Linux:
-	sudo -H apt-get install git
-	sudo -H apt-get install python3
-	sudo -H apt-get install python3-matplotlib
-	sudo -H apt-get install python3-pip
-	curl -O https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp34-cp34m-linux_x86_64.whl
-	mv tensorflow-0.8.0-cp34-cp34m-linux_x86_64.whl tensorflow-0.8.0-cp35-cp35m-linux_x86_64.whl
-	sudo -H pip3 install --upgrade tensorflow-0.8.0-cp35-cp35m-linux_x86_64.whl
-	sudo -H pip3 install --upgrade cycler
+	sudo apt-get install git python3 python3-matplotlib python3-pip
+	sudo apt-get build-dep matplotlib
+        sudo pip3 install --upgrade matplotlib
+        sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp34-cp34m-linux_x86_64.whl
 
     The cycler install is to work around a bug in the current matplotlib release. It should be fixed in the next one.
     The renaming of the tensorflow install file is to overcome a bug in tensorflow. This should get fixed too.


### PR DESCRIPTION
This command "curl -O https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp34-cp34m-linux_x86_64.whl" was raising an error, and I think that with the last verison of matlotlib, it is useless to install cycler.
I also add the build-dep for matplotlib because it is necessary for upgrading matplotlib.

This has been tested on an empty Ubuntu 14.04 system
