### PR TITLE
Replacing deprecated softmax_cross_entropy_with_logits function

### DIFF
--- a/mnist_2.0_five_layers_sigmoid.py
+++ b/mnist_2.0_five_layers_sigmoid.py
@@ -69,9 +69,9 @@ Ylogits = tf.matmul(Y4, W5) + B5
 Y = tf.nn.softmax(Ylogits)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)

--- a/mnist_2.1_five_layers_relu_lrdecay.py
+++ b/mnist_2.1_five_layers_relu_lrdecay.py
@@ -72,9 +72,9 @@ Ylogits = tf.matmul(Y4, W5) + B5
 Y = tf.nn.softmax(Ylogits)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)

--- a/mnist_2.2_five_layers_relu_lrdecay_dropout.py
+++ b/mnist_2.2_five_layers_relu_lrdecay_dropout.py
@@ -83,9 +83,9 @@ Ylogits = tf.matmul(Y4d, W5) + B5
 Y = tf.nn.softmax(Ylogits)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)

--- a/mnist_3.0_convolutional.py
+++ b/mnist_3.0_convolutional.py
@@ -79,9 +79,9 @@ Ylogits = tf.matmul(Y4, W5) + B5
 Y = tf.nn.softmax(Ylogits)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)

--- a/mnist_3.1_convolutional_bigger_dropout.py
+++ b/mnist_3.1_convolutional_bigger_dropout.py
@@ -82,9 +82,9 @@ Ylogits = tf.matmul(YY4, W5) + B5
 Y = tf.nn.softmax(Ylogits)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)

--- a/mnist_4.0_batchnorm_five_layers_sigmoid.py
+++ b/mnist_4.0_batchnorm_five_layers_sigmoid.py
@@ -129,9 +129,9 @@ Y = tf.nn.softmax(Ylogits)
 update_ema = tf.group(update_ema1, update_ema2, update_ema3, update_ema4)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)

--- a/mnist_4.1_batchnorm_five_layers_relu.py
+++ b/mnist_4.1_batchnorm_five_layers_relu.py
@@ -135,9 +135,9 @@ Y = tf.nn.softmax(Ylogits)
 update_ema = tf.group(update_ema1, update_ema2, update_ema3, update_ema4)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)

--- a/mnist_4.2_batchnorm_convolutional.py
+++ b/mnist_4.2_batchnorm_convolutional.py
@@ -122,9 +122,9 @@ Y = tf.nn.softmax(Ylogits)
 update_ema = tf.group(update_ema1, update_ema2, update_ema3, update_ema4)
 
 # cross-entropy loss function (= -sum(Y_i * log(Yi)) ), normalised for batches of 100  images
-# TensorFlow provides the softmax_cross_entropy_with_logits function to avoid numerical stability
+# TensorFlow provides the softmax_cross_entropy_with_logits_v2 function to avoid numerical stability
 # problems with log(0) which is NaN
-cross_entropy = tf.nn.softmax_cross_entropy_with_logits(logits=Ylogits, labels=Y_)
+cross_entropy = tf.nn.softmax_cross_entropy_with_logits_v2(logits=Ylogits, labels=Y_)
 cross_entropy = tf.reduce_mean(cross_entropy)*100
 
 # accuracy of the trained model, between 0 (worst) and 1 (best)


### PR DESCRIPTION
Future major versions of TensorFlow will allow gradients to flow into the labels input on backprop by default.

[`tf.nn.softmax_cross_entropy_with_logits`](https://www.tensorflow.org/api_docs/python/tf/nn/softmax_cross_entropy_with_logits) (from [`tensorflow.python.ops.nn_ops`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/nn_ops.py)) is deprecated and will be removed in a future version.

Replacing it with [`tf.nn.softmax_cross_entropy_with_logits_v2`](https://www.tensorflow.org/api_docs/python/tf/nn/softmax_cross_entropy_with_logits_v2)