### PR TITLE
Fix datatype of random seed

### DIFF
--- a/mnist_4.2_batchnorm_convolutional.py
+++ b/mnist_4.2_batchnorm_convolutional.py
@@ -18,7 +18,7 @@ import tensorflowvisu
 import math
 from tensorflow.examples.tutorials.mnist import input_data as mnist_data
 print("Tensorflow version " + tf.__version__)
-tf.set_random_seed(0.0)
+tf.set_random_seed(0)
 
 # Download images and labels into mnist.test (10K images+labels) and mnist.train (60K images+labels)
 mnist = mnist_data.read_data_sets("data", one_hot=True, reshape=False, validation_size=0)


### PR DESCRIPTION
Running the script _mnist_4.2_batchnorm_convolutional.py_ produces the error: `TypeError: Cannot cast array from dtype('float64') to dtype('int64') according to the rule 'safe'`.

The seed should be an integer instead of a float: https://github.com/tensorflow/tensorflow/blob/r1.7/tensorflow/python/framework/random_seed.py#L177
